### PR TITLE
Fix CI lint errors (issue #10)

### DIFF
--- a/tests/unit/concurrent-downloads.test.ts
+++ b/tests/unit/concurrent-downloads.test.ts
@@ -25,7 +25,7 @@ describe('Concurrent Downloads', () => {
 
     // Mock fetch to track download timeline and simulate delays
     fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = url.toString();
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
       const tileIdMatch = urlStr.match(/\/([NS]\d{2}[EW]\d{3})\.hgt\.gz$/);
       const tileId = tileIdMatch ? tileIdMatch[1] : 'unknown';
 

--- a/tests/unit/download-filename.test.ts
+++ b/tests/unit/download-filename.test.ts
@@ -18,7 +18,7 @@ function generateDownloadFilename(friendlyDescription: string | null | undefined
     filename = friendlyDescription
       .replace(/\(/g, '[')         // Replace ( with [
       .replace(/\)/g, ']')         // Replace ) with ]
-      .replace(/[^\w\s\[\]-]/g, '') // Remove special chars except spaces, brackets, and hyphens
+      .replace(/[^\w\s[\]-]/g, '') // Remove special chars except spaces, brackets, and hyphens
       .replace(/\s+/g, '_')        // Replace spaces with underscores
       .replace(/_+/g, '_')         // Remove duplicate underscores
       .toLowerCase();
@@ -55,7 +55,7 @@ function generateDownloadFilenameImproved(friendlyDescription: string | null | u
   filename = description
     .replace(/\(/g, '[')           // Replace ( with [
     .replace(/\)/g, ']')           // Replace ) with ]
-    .replace(/[^\w\s\[\]-]/g, '')  // Remove special chars except spaces, brackets, and hyphens
+    .replace(/[^\w\s[\]-]/g, '')  // Remove special chars except spaces, brackets, and hyphens
     .replace(/\s+/g, '_')          // Replace spaces with underscores
     .replace(/_+/g, '_')           // Remove duplicate underscores
     .replace(/^_|_$/g, '')         // Trim underscores from start/end


### PR DESCRIPTION
## Summary
- Fixed 3 lint errors blocking CI pipeline
- All tests now pass locally with zero lint errors

## Changes
- Fixed URL type checking in concurrent-downloads.test.ts
- Fixed regex escape sequences in download-filename.test.ts  
- Cleaned up type assertions

## Test plan
- [x] Run `npm run lint` - passes with 0 errors
- [x] Run `npm run test -- --run` - all tests pass
- [x] Run `npm run typecheck` - no TypeScript errors
- [x] Run `npm run build` - builds successfully

Fixes #10