### PR TITLE
Fix broken GitHub link in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
             SRTM2TAK v0.1.0<br>
             Download SRTM elevation data for ATAK
           </p>
-          <a href="https://github.com/your-username/SRTM2TAK" target="_blank" rel="noopener" class="link">GitHub</a>
+          <a href="https://github.com/joshuafuller/SRTM2TAK" target="_blank" rel="noopener" class="link">GitHub</a>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- Fixed broken GitHub link that was using placeholder 'your-username'
- Updated to point to correct repository: joshuafuller/SRTM2TAK

## Changes
- Updated GitHub link in index.html About section from 'your-username' to 'joshuafuller'

## Test plan
- [x] Verified link points to correct repository
- [x] Link opens in new tab with rel='noopener' for security