### PR TITLE
Fix hamburger menu alignment on wide screens

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -127,8 +127,6 @@ html, body {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-md);
-  max-width: 1200px;
-  margin: 0 auto;
 }
 
 .app-title {


### PR DESCRIPTION
## Summary
- Fixes hamburger menu alignment issue on screens wider than 1200px
- Removes max-width constraint from header-content container

## Problem
The hamburger menu was not staying aligned to the right edge of the viewport on wider screens. Instead, it would float inward due to the header-content container being limited to 1200px width and centered.

## Solution
Removed the `max-width: 1200px` and `margin: 0 auto` styles from `.header-content`, allowing the header to span the full viewport width on all screen sizes.

## Testing
- Tested on various screen widths
- Hamburger menu now consistently stays at the right edge
- Mobile layouts remain unaffected

Fixes #16