### PR TITLE
ci: auto-merge Dependabot patch & minor updates after CI passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,28 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
+
+  # Auto-merge Dependabot patch & minor updates once CI is green.
+  # Gated purely by `needs: [test, e2e]` — this job is skipped if either fails,
+  # so CI is the merge gate (no branch protection required). Major bumps are
+  # never auto-merged: they fall through the version-type guard for manual review.
+  dependabot-auto-merge:
+    needs: [test, e2e]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Fetch Dependabot metadata
+      id: meta
+      uses: dependabot/fetch-metadata@v2
+
+    - name: Merge patch & minor updates
+      if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+      run: gh pr merge --merge "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a `dependabot-auto-merge` job to `ci.yml`.

**Behavior**
- Runs **only** on Dependabot PRs (`github.actor == 'dependabot[bot]'`).
- `needs: [test, e2e]` → the job is skipped unless the unit/build matrix **and** the Playwright e2e suite both pass. **CI is the gate** — no branch protection needed, so your direct pushes to `main` keep working.
- Merges **patch + minor** updates (incl. security patches at those levels). **Major** bumps are never auto-merged — they wait for your review.
- Token: `GITHUB_TOKEN` with `contents:write` + `pull-requests:write`, PR URL passed via env (no injection surface).

**Known caveat (by design):** GitHub does not trigger new workflow runs from a `GITHUB_TOKEN` push, so an auto-merged dep lands on `main` but the Pages **deploy runs on the next push**, not instantly. For most updates (dev-deps/transitive) this is irrelevant. If you want instant redeploy on auto-merge, add a PAT as a Dependabot secret and I'll switch the merge step to use it.

**Not included (offer):** a `dependabot.yml` to enable grouped weekly *version* updates (not just security) — left out to avoid an immediate PR flood. Say the word and I'll add it.